### PR TITLE
Add 4.1 to the version list

### DIFF
--- a/.github/workflows/publish-apidocs.yml
+++ b/.github/workflows/publish-apidocs.yml
@@ -1,8 +1,8 @@
 name: Generate API docs and publish to Github Pages
 
 env:
-  BRANCHLIST: "MOODLE_39_STABLE MOODLE_311_STABLE MOODLE_400_STABLE master"
-  VERSIONLIST: "3.9 3.11 4.00 master"
+  BRANCHLIST: "MOODLE_39_STABLE MOODLE_311_STABLE MOODLE_400_STABLE MOODLE_401_STABLE master"
+  VERSIONLIST: "3.9 3.11 4.00 4.1 master"
 
 on:
   schedule:


### PR DESCRIPTION
Part of point 15 of the [1-week prior to release tasks](https://moodledev.io/general/development/process/release#1-week-prior)
> Update the BRANCHLIST and VERSIONLIST in the JSDoc and PHPDoc repositories with the list of supported versions. These are built on a Sunday so this should be done in the final week before release.